### PR TITLE
feat: camera icon on snapshot entry points (header button + panel title)

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -2,6 +2,11 @@
 
 Notable changes to dsh-undo-savepoint. Dates are in local time (UTC+8). 中文版:[CHANGELOG.md](CHANGELOG.md)
 
+## [Unreleased]
+
+### Added
+- **Camera icon on the snapshot entry points**: the conversation-header "Snapshots" button and the snapshot-manager panel title now carry a camera glyph in the official DSH filled-icon style (16×16 monochrome `currentColor`: body outline + viewfinder hump + lens ring, adapts to the theme color; the `CameraIcon` component is reusable)
+
 ## [0.3.3] - 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 dsh-undo-savepoint 的重要变更。日期为本地时间(UTC+8)。English version: [CHANGELOG.en.md](CHANGELOG.en.md)
 
+## [Unreleased]
+
+### 新增
+- **快照入口相机图标**：会话头部「快照」按钮与快照管理面板标题新增官方填充式风格的相机图标（16×16 单色 `currentColor`，机身轮廓 + 取景器凸起 + 镜头圆环，随主题色自适应；`CameraIcon` 组件可复用）
+
 ## [0.3.3] - 2026-08-16
 
 ### 新增

--- a/lib/client.js
+++ b/lib/client.js
@@ -247,6 +247,25 @@ window.__ModuleLoader__.load({
 		const LOC_KEYS = { manual: "loc.manual", auto: "loc.auto", legacy: "loc.legacy" };
 		//#endregion
 		//#region UndoHeader (session header actions)
+		/** Camera glyph for the snapshot entry points (official DSH filled-style icon, 16x16, currentColor). */
+		function CameraIcon({ size = 16 }) {
+			return (0, react_jsx_runtime.jsxs)("svg", {
+				width: size,
+				height: size,
+				viewBox: "0 0 16 16",
+				fill: "none",
+				xmlns: "http://www.w3.org/2000/svg",
+				children: [(0, react_jsx_runtime.jsx)("path", {
+					d: "M6 2.2H10V3.4H11.5A2 2 0 0 1 13.5 5.4V11.4A2 2 0 0 1 11.5 13.4H4.5A2 2 0 0 1 2.5 11.4V5.4A2 2 0 0 1 4.5 3.4H6ZM3.8 5.4V11.4A0.7 0.7 0 0 0 4.5 12.1H11.5A0.7 0.7 0 0 0 12.2 11.4V5.4A0.7 0.7 0 0 0 11.5 4.7H4.5A0.7 0.7 0 0 0 3.8 5.4Z",
+					fill: "currentColor",
+					fillRule: "evenodd"
+				}), (0, react_jsx_runtime.jsx)("path", {
+					d: "M8 6.2A2.2 2.2 0 1 0 8 10.6A2.2 2.2 0 1 0 8 6.2ZM8 7.5A0.9 0.9 0 1 0 8 9.3A0.9 0.9 0 1 0 8 7.5Z",
+					fill: "currentColor",
+					fillRule: "evenodd"
+				})]
+			});
+		}
 		/** Undo/redo/snapshot buttons in the conversation header. */
 		function UndoHeader({ t, onOpenPanel }) {
 			const [busy, setBusy] = (0, react.useState)(false);
@@ -319,7 +338,7 @@ window.__ModuleLoader__.load({
 						title: t("snapshots.aria"),
 						"aria-label": t("snapshots.aria"),
 						onClick: () => { onOpenPanel(); },
-						children: t("snapshots")
+						children: [(0, react_jsx_runtime.jsx)(CameraIcon, { size: 14 }), t("snapshots")]
 					}),
 					msg !== null && (0, react_jsx_runtime.jsx)("span", {
 						className: styles.msg + " " + (msgOk ? styles.ok : styles.err),
@@ -426,6 +445,7 @@ window.__ModuleLoader__.load({
 						(0, react_jsx_runtime.jsx)("div", {
 							className: styles.head,
 							children: [
+								(0, react_jsx_runtime.jsx)(CameraIcon, { size: 16 }),
 								(0, react_jsx_runtime.jsx)("span", { className: styles.title, children: t("panel.title") }),
 								(0, react_jsx_runtime.jsx)("button", {
 									type: "button", className: styles.close, "aria-label": t("panel.close"),


### PR DESCRIPTION
## Summary

Adds a camera glyph to the plugin's own UI surfaces, in the official DSH filled-icon style (16x16 monochrome currentColor, adapts to theme color):

- conversation-header **Snapshots** button (14px icon + label, inline-flex layout already has a 3px gap)
- snapshot-manager **panel title** (16px icon before the title)

The glyph is a new reusable CameraIcon component in lib/client.js: body outline (evenodd outer-minus-inner, 1.3 wall thickness, rounded corners) + solid viewfinder hump + lens ring (evenodd double circle, 1.3 ring thickness).

## Context

The settings-page **nav rail icon** for the dsh-undo section is hardcoded inside the DSH settings shell (@deepseek-ai/dsh-client-ui-settings-general, 
avIcon(id) — unknown ids fall back to the gear), and section registrations are projected to {id, order, label} only, so a plugin cannot supply its own nav icon. This PR therefore carries the camera identity on the plugin's own entry points instead.

## Validation

- 
ode --check lib/client.js passes
- CI-style local run: 
pm install --no-save @deepseek-ai/dsh-tools then 
ode tools/smoke-test.mjs — **101/101 passed**; 
ode tools/e2e-watch.mjs — **10/10 passed**