### PR TITLE
fix: snapshot pnpm-lock.yaml and home cordis.patch.yml, reconcile deps on restore

### DIFF
--- a/CHANGELOG.en.md
+++ b/CHANGELOG.en.md
@@ -2,6 +2,21 @@
 
 Notable changes to dsh-undo-savepoint. Dates are in local time (UTC+8). 中文版:[CHANGELOG.md](CHANGELOG.md)
 
+## [Unreleased]
+
+### Fixed
+- **Boot-critical snapshot coverage**: profile-level `pnpm-lock.yaml` and home-level `cordis.patch.yml` are now snapshotted, matching the state `dsh plugin add/update/remove` actually mutates (issue #8)
+- **Dependency reconciliation after restore**: when undo/redo/restore touches `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml`, the default result reports that `node_modules` may be out of sync and prints the rebuild command. An explicit sync runs `pnpm install --frozen-lockfile` (plain `pnpm install` without a lockfile); a failed install never rolls back the restored config files
+
+### Entry points
+- Offline CLI: `dsh-undo.ps1 undo|redo|restore -SyncDeps`
+- Model tool: `undo_restore` gains an optional `sync_deps` boolean
+- REST: `/api/undo/undo|redo|restore` accept optional `syncDeps`
+
+### Tests
+- smoke 106 → 112 (lockfile/home-patch snapshots, byte-level restore, default report-only, explicit sync command verification)
+- e2e 10/10, no regressions
+
 ## [0.3.5] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 dsh-undo-savepoint 的重要变更。日期为本地时间(UTC+8)。English version: [CHANGELOG.en.md](CHANGELOG.en.md)
 
+## [Unreleased]
+
+### 修复
+- **快照补齐启动关键文件**：新增 profile 级 `pnpm-lock.yaml` 与 home 级 `cordis.patch.yml`，与 `dsh plugin add/update/remove` 实际改动的状态对齐（issue #8）
+- **恢复后对账依赖状态**：undo/redo/restore 触及 `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` 时，默认报告 `node_modules` 可能不同步并给出重建命令；显式开启同步时执行 `pnpm install --frozen-lockfile`（无 lockfile 回退普通 `pnpm install`），安装失败不回滚已还原的配置文件
+
+### 入口
+- 离线 CLI：`dsh-undo.ps1 undo|redo|restore -SyncDeps`
+- 模型工具：`undo_restore` 新增 `sync_deps` 布尔参数
+- REST：`/api/undo/undo|redo|restore` 接受可选 `syncDeps`
+
+### 测试
+- smoke 106 → 112（新增 lockfile/home patch 快照、字节级还原、默认不同步、显式同步命令校验）
+- e2e 10/10 无回归
+
 ## [0.3.5] - 2026-08-17
 
 ### 修复

--- a/README.en.md
+++ b/README.en.md
@@ -54,7 +54,8 @@ An undo/rollback system for [DeepSeek Harness (DSH)](https://github.com/deepseek
 
 ## What is snapshotted & where
 
-The snapshot captures DSH's 6 config files: `cordis.patch.yml`, `package.json`, `cordis.yml`, `pnpm-workspace.yaml` (under the profile) + `settings.yaml`, `.env` (under `$DSH_HOME`, default `~/.dsh`).
+The snapshot captures DSH's boot-critical config: `cordis.patch.yml`, `package.json`, `cordis.yml`, `pnpm-workspace.yaml`, `pnpm-lock.yaml` (under the profile) + `cordis.patch.yml`, `settings.yaml`, `.env`, `.credentials.yaml` (under `$DSH_HOME`, default `~/.dsh`).
+When a restore touches `package.json` / `pnpm-lock.yaml`, the default behavior only reports that `node_modules` may be out of sync. To rebuild dependencies, pass `-SyncDeps` (offline CLI), `sync_deps: true` (chat tool), or `syncDeps: true` (REST); the plugin runs `pnpm install --frozen-lockfile` (plain `pnpm install` when there is no lockfile). A failed install leaves the restored config files in place.
 
 | Store | Default path (configurable in settings) | Contents |
 |---|---|---|
@@ -200,8 +201,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint-gu
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" list
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" snapshot -Label "reason"
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo -SyncDeps
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" redo
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force -SyncDeps
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" remove -Id <id>
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" prune -KeepAuto 20
 
@@ -218,9 +221,9 @@ Typical rescue scenario: **DSH fails to boot with something like `duplicate load
 | `GET /api/undo/status` | `{canUndo, canRedo, total}` |
 | `GET /api/undo/list` | Snapshot list (with location: manual/auto/legacy) |
 | `GET/POST /api/undo/settings` | Read/write save options (auto-save, debounce, keep count, dirs); POST applies immediately |
-| `POST /api/undo/undo` | Undo the last change |
-| `POST /api/undo/redo` | Redo the last undo |
-| `POST /api/undo/restore` | body `{id}` — restore to a fixed version |
+| `POST /api/undo/undo` | Undo the last change; optional body `{syncDeps: true}` rebuilds `node_modules` from the restored lockfile |
+| `POST /api/undo/redo` | Redo the last undo; optional body `{syncDeps: true}` |
+| `POST /api/undo/restore` | body `{id, syncDeps?}` — restore to a fixed version |
 | `POST /api/undo/remove` | body `{id}` — delete a snapshot |
 | `POST /api/undo/snapshot` | body `{reason}` — manual save |
 | `POST /api/undo/pick-dir` | Open the native folder picker, return the chosen path |

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@
 
 ## 快照内容与存储
 
-快照对象是 DSH 的 6 个配置文件:`cordis.patch.yml`、`package.json`、`cordis.yml`、`pnpm-workspace.yaml`(profile 下)+ `settings.yaml`、`.env`($DSH_HOME 下,默认 ~/.dsh)。
+快照对象是 DSH 的启动关键配置:`cordis.patch.yml`、`package.json`、`cordis.yml`、`pnpm-workspace.yaml`、`pnpm-lock.yaml`(profile 下)+ `cordis.patch.yml`、`settings.yaml`、`.env`、`.credentials.yaml`($DSH_HOME 下,默认 ~/.dsh)。
+恢复涉及 `package.json` / `pnpm-lock.yaml` 时,默认只报告 `node_modules` 可能不同步;需要真正重建依赖时加 `-SyncDeps`(离线 CLI)、`sync_deps: true`(对话工具)或 `syncDeps: true`(REST),插件会执行 `pnpm install --frozen-lockfile`(无 lockfile 时普通 `pnpm install`)。安装失败不影响已经还原的配置文件。
 
 | 库 | 默认路径(可在设置中修改) | 内容 |
 |---|---|---|
@@ -202,8 +203,10 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint-gu
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" list
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" snapshot -Label "原因"
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo -SyncDeps
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" redo
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force -SyncDeps
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" remove -Id <id>
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" prune -KeepAuto 20
 
@@ -220,9 +223,9 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-plugin.ps1" add <
 | `GET /api/undo/status` | `{canUndo, canRedo, total}` |
 | `GET /api/undo/list` | 快照列表(含 location: manual/auto/legacy) |
 | `GET/POST /api/undo/settings` | 读/写保存参数(自动保存、防抖、保留数、目录),POST 即时生效 |
-| `POST /api/undo/undo` | 撤销上一步 |
-| `POST /api/undo/redo` | 恢复 |
-| `POST /api/undo/restore` | body `{id}` 回退到指定版本 |
+| `POST /api/undo/undo` | 撤销上一步;可选 body `{syncDeps: true}` 按还原后的 lockfile 重建 `node_modules` |
+| `POST /api/undo/redo` | 恢复;可选 body `{syncDeps: true}` |
+| `POST /api/undo/restore` | body `{id, syncDeps?}` 回退到指定版本 |
 | `POST /api/undo/remove` | body `{id}` 删除快照 |
 | `POST /api/undo/snapshot` | body `{reason}` 手动保存 |
 | `POST /api/undo/pick-dir` | 弹出系统目录选择器,返回选中路径 |

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,6 +157,8 @@ const DEFAULT_SPEC = {
     { root: 'profile', rel: 'package.json' },
     { root: 'profile', rel: 'cordis.yml' },
     { root: 'profile', rel: 'pnpm-workspace.yaml' },
+    { root: 'profile', rel: 'pnpm-lock.yaml' },
+    { root: 'home', rel: 'cordis.patch.yml' },
     { root: 'home', rel: 'settings.yaml' },
     { root: 'home', rel: '.env' },
     { root: 'home', rel: '.credentials.yaml' },
@@ -805,6 +807,68 @@ async function applySnapshot(cfg, snap) {
   return { restored, missing, notes };
 }
 
+/** Config files whose restore changes which package versions the profile should resolve. */
+const DEPENDENCY_FILES = new Set(['profile-package.json', 'profile-pnpm-lock.yaml', 'profile-pnpm-workspace.yaml']);
+
+/** Run pnpm with bounded output; a non-zero exit is a normal result, never a throw. */
+function runPnpm(args, cwd) {
+  return new Promise((resolve) => {
+    // Windows npm shims are .cmd files; spawn cmd.exe with the verb list so
+    // no user-controlled string is concatenated into a shell command line.
+    const windows = process.platform === 'win32';
+    execFile(windows ? (process.env.ComSpec ?? 'cmd.exe') : 'pnpm', windows ? ['/d', '/s', '/c', 'pnpm', ...args] : args, {
+      cwd,
+      windowsHide: true,
+      timeout: 10 * 60 * 1000,
+      maxBuffer: 10 * 1024 * 1024,
+    }, (error, stdout, stderr) => {
+      const tail = (value) => String(value ?? '').slice(-4000);
+      resolve({
+        ok: error == null,
+        code: typeof error?.code === 'string' ? error.code : (error == null ? 0 : 1),
+        stdout: tail(stdout),
+        stderr: tail(stderr),
+        error: error == null ? '' : String(error.message ?? error),
+      });
+    });
+  });
+}
+
+/**
+ * Reconcile profile dependencies after restoring manifest/lock/workspace files.
+ * Default is report-only: a package-manager run can hit the network, lifecycle
+ * scripts, or file locks, so it must stay opt-in. An explicit sync never fails
+ * the restore itself — restored config files are already on disk.
+ */
+async function reconcileDependencies(cfg, restored, syncDeps) {
+  const touched = restored.some((name) => DEPENDENCY_FILES.has(name));
+  if (!touched) return { touched: false, synced: false };
+  const profileDir = rootDir(cfg, 'profile');
+  if (syncDeps !== true) {
+    return {
+      touched: true,
+      synced: false,
+      note: `dependency state may be out of sync — run 'dsh plugin --profile ${cfg.profileName} install' (or 'pnpm install --frozen-lockfile' in ${profileDir})`,
+    };
+  }
+  const lockPath = join(profileDir, 'pnpm-lock.yaml');
+  const args = (await pathExists(lockPath)) ? ['install', '--frozen-lockfile'] : ['install'];
+  const startedAt = Date.now();
+  const result = await runPnpm(args, profileDir);
+  const command = `pnpm ${args.join(' ')}`;
+  return {
+    touched: true,
+    synced: result.ok,
+    command,
+    profileDir,
+    durationMs: Date.now() - startedAt,
+    ...result,
+    note: result.ok
+      ? `dependencies synced (${command})`
+      : `dependency sync failed (${command}): ${result.stderr || result.error}`,
+  };
+}
+
 /** Keep the undo plugin itself mounted: append its insert row to cordis.patch.yml when missing. */
 /**
  * Keep the plugin loadable after restores, WITHOUT double-loading:
@@ -1117,8 +1181,9 @@ async function appendRollbackLog(cfg, entry) {
  *   since the undo); consuming it un-steps matching regular snapshots so undo
  *   can walk back through them again.
  */
-async function restore(cfg, mode, id) {
+async function restore(cfg, mode, id, options = {}) {
   if (hasOpenTurn()) return busyError();
+  const syncDeps = options.syncDeps === true;
   const list = await listSnapshots(cfg);
 
   if (mode === 'undo') {
@@ -1142,9 +1207,10 @@ async function restore(cfg, mode, id) {
       if (stepped) await markFlag(candidates[0].s, 'stepped', true);
       const remounted = await ensureMount(cfg);
       const needsRestart = restored.some((n) => n === 'profile-cordis.patch.yml' || n === 'profile-package.json' || n.startsWith('plugin:') || n.startsWith('profile:'));
+      const deps = await reconcileDependencies(cfg, restored, syncDeps);
       const preflight = await preflightSnapshot(cfg, target.s);
-      await appendRollbackLog(cfg, { mode: 'undo', targetId: target.s.id, targetKind: target.s.kind, preSnapshotId: pre.id, files: restored, missing, notes, needsRestart, preflightMissing: preflight.missing });
-      return { ok: true, restored, missing, notes, needsRestart, preflight, targetId: target.s.id, targetKind: target.s.kind, targetReason: target.s.reason, preSnapshotId: pre.id, stepped, remounted };
+      await appendRollbackLog(cfg, { mode: 'undo', targetId: target.s.id, targetKind: target.s.kind, preSnapshotId: pre.id, files: restored, missing, notes, needsRestart, deps, preflightMissing: preflight.missing });
+      return { ok: true, restored, missing, notes, needsRestart, deps, preflight, targetId: target.s.id, targetKind: target.s.kind, targetReason: target.s.reason, preSnapshotId: pre.id, stepped, remounted };
     } finally {
       cfg.suppressAuto--;
     }
@@ -1169,9 +1235,10 @@ async function restore(cfg, mode, id) {
         if (sameState(preState, await stateOf(s))) await markFlag(s, 'stepped', false);
       }
       const needsRestart = restored.some((n) => n === 'profile-cordis.patch.yml' || n === 'profile-package.json' || n.startsWith('plugin:') || n.startsWith('profile:'));
+      const deps = await reconcileDependencies(cfg, restored, syncDeps);
       const preflight = await preflightSnapshot(cfg, pre);
-      await appendRollbackLog(cfg, { mode: 'redo', targetId: pre.id, files: restored, missing, notes, needsRestart, preflightMissing: preflight.missing });
-      return { ok: true, restored, missing, notes, needsRestart, preflight, targetId: pre.id, preSnapshotId: pre.id, remounted: false };
+      await appendRollbackLog(cfg, { mode: 'redo', targetId: pre.id, files: restored, missing, notes, needsRestart, deps, preflightMissing: preflight.missing });
+      return { ok: true, restored, missing, notes, needsRestart, deps, preflight, targetId: pre.id, preSnapshotId: pre.id, remounted: false };
     } finally {
       cfg.suppressAuto--;
     }
@@ -1186,9 +1253,10 @@ async function restore(cfg, mode, id) {
     const { restored, missing, notes } = await applySnapshot(cfg, target);
     const remounted = await ensureMount(cfg);
     const needsRestart = restored.some((n) => n === 'profile-cordis.patch.yml' || n === 'profile-package.json' || n.startsWith('plugin:') || n.startsWith('profile:'));
+    const deps = await reconcileDependencies(cfg, restored, syncDeps);
     const preflight = await preflightSnapshot(cfg, target);
-    await appendRollbackLog(cfg, { mode: 'restore', targetId: target.id, targetKind: target.kind, preSnapshotId: pre.id, files: restored, missing, notes, needsRestart, preflightMissing: preflight.missing });
-    return { ok: true, restored, missing, notes, needsRestart, preflight, targetId: target.id, targetKind: target.kind, targetReason: target.reason, preSnapshotId: pre.id, stepped: false, remounted };
+    await appendRollbackLog(cfg, { mode: 'restore', targetId: target.id, targetKind: target.kind, preSnapshotId: pre.id, files: restored, missing, notes, needsRestart, deps, preflightMissing: preflight.missing });
+    return { ok: true, restored, missing, notes, needsRestart, deps, preflight, targetId: target.id, targetKind: target.kind, targetReason: target.reason, preSnapshotId: pre.id, stepped: false, remounted };
   } finally {
     cfg.suppressAuto--;
   }
@@ -1368,6 +1436,14 @@ function renderRestoreResult(r) {
   if (r.remounted) lines.push('dsh-undo-savepoint mount re-ensured in cordis.patch.yml');
   if (Array.isArray(r.missing) && r.missing.length > 0) lines.push(`Not restored: ${r.missing.join(', ')}`);
   if (r.needsRestart) lines.push('NOTE: a restart of DSH is required for the restored state to take effect.');
+  if (r.deps?.touched) {
+    if (r.deps.synced) {
+      lines.push(`Dependencies synced: ${r.deps.command}`);
+    } else {
+      lines.push(`⚠️ ${r.deps.note}`);
+      lines.push('Restored config files are in place; re-run with sync_deps=true to rebuild dependencies automatically.');
+    }
+  }
   if (Array.isArray(r.preflight?.missing) && r.preflight.missing.length > 0) {
     lines.push(`⚠️ Cross-machine preflight: referenced but NOT resolvable on this machine: ${r.preflight.missing.join(', ')}`);
     lines.push('DSH may fail to start after restore — install them first, or use undo_safe_mode action "on" to boot with only the undo system.');
@@ -1409,6 +1485,7 @@ When the user asks to undo the previous action ("撤销上一步", "回退", "�
 7. Config-state confusion: when the user is confused about the current config (a plugin/skin/setting suddenly missing or different, or a long futile debugging loop), FIRST call undo_recent to check whether a recent rollback explains it; if so, tell the user exactly which files were rolled back and when. Rollbacks may have happened in another session or via the offline tools, so the user/AI may not have seen them happen.
 8. Plugin code: snapshots also include user-plugin CODE files (junction targets under node_modules, e.g. D:\\dsh\\plugins\\*, plus profile-local files like router-global.mjs). A broken plugin EDIT (e.g. "yield* (intermediate value) is not async iterable") can be rolled back even when no config file changed — undo_list rows show the plugin file count.
 9. SAFE MODE: when DSH cannot boot at all or a plugin breaks startup, use undo_safe_mode action "on" to disable every user plugin except undo itself, then restart DSH and diagnose; action "off" restores the previous plugin set (restart again). undo_list crash alerts name a concrete last-known-good snapshot to restore (undo_restore mode "id").
+10. Dependency sync: when a restore touches package.json / pnpm-lock.yaml, the result reports that node_modules may be out of sync. Re-run undo_restore with sync_deps=true only when the user confirms, because it runs pnpm install --frozen-lockfile.
 Note: this system only reverts DSH config/plugin/skin state, not chat history.`;
 
 /** 最近一次 apply() 的 ctx 引用（供 hasOpenTurn 取 session store）。 */
@@ -1595,6 +1672,7 @@ export function apply(ctx, config = {}) {
     parameters: {
       mode: { type: 'string', required: true, description: '"undo" | "redo" | "id"' },
       snapshot_id: { type: 'string', description: 'Required when mode is "id".' },
+      sync_deps: { type: 'boolean', description: 'After restoring package.json/pnpm-lock.yaml, run pnpm install --frozen-lockfile so node_modules matches the snapshot. Default false: only reports that dependencies may be out of sync.' },
     },
     output: TEXT_OUTPUT,
     isConcurrencySafe: () => true,
@@ -1602,7 +1680,7 @@ export function apply(ctx, config = {}) {
       const mode = typeof args?.mode === 'string' ? args.mode : 'undo';
       const id = typeof args?.snapshot_id === 'string' ? args.snapshot_id : undefined;
       if (!['undo', 'redo', 'id'].includes(mode)) return `undo_restore: unknown mode "${mode}" (use undo | redo | id)`;
-      return renderRestoreResult(await restore(cfg, mode, id));
+      return renderRestoreResult(await restore(cfg, mode, id, { syncDeps: args?.sync_deps === true }));
     },
   })), 'dsh-undo-savepoint.tool.restore');
 
@@ -1889,16 +1967,18 @@ export function apply(ctx, config = {}) {
             return send(res, 200, { ok: true, ...r });
           }
           if (method === 'POST' && path === '/api/undo/undo') {
-            const r = await restore(cfg, 'undo');
+            const body = await readJson(req);
+            const r = await restore(cfg, 'undo', undefined, { syncDeps: body?.syncDeps === true });
             return send(res, 200, { ok: r.ok, ...r });
           }
           if (method === 'POST' && path === '/api/undo/redo') {
-            const r = await restore(cfg, 'redo');
+            const body = await readJson(req);
+            const r = await restore(cfg, 'redo', undefined, { syncDeps: body?.syncDeps === true });
             return send(res, 200, { ok: r.ok, ...r });
           }
           if (method === 'POST' && path === '/api/undo/restore') {
             const body = await readJson(req);
-            const r = await restore(cfg, 'id', body?.id);
+            const r = await restore(cfg, 'id', body?.id, { syncDeps: body?.syncDeps === true });
             return send(res, 200, { ok: r.ok, ...r });
           }
           if (method === 'POST' && path === '/api/undo/remove') {

--- a/lib/spec.json
+++ b/lib/spec.json
@@ -4,6 +4,8 @@
     { "root": "profile", "rel": "package.json" },
     { "root": "profile", "rel": "cordis.yml" },
     { "root": "profile", "rel": "pnpm-workspace.yaml" },
+    { "root": "profile", "rel": "pnpm-lock.yaml" },
+    { "root": "home", "rel": "cordis.patch.yml" },
     { "root": "home", "rel": "settings.yaml" },
     { "root": "home", "rel": ".env" },
     { "root": "home", "rel": ".credentials.yaml" }

--- a/tools/dsh-undo-savepoint-gui.ps1
+++ b/tools/dsh-undo-savepoint-gui.ps1
@@ -305,6 +305,12 @@ $form.Controls.Add($status)
 
 function Set-Status([string]$Text) { $status.Text = $Text }
 
+function Show-DepsNote($R) {
+    if ($R.deps.touched -and -not $R.deps.synced) {
+        Set-Status "$($status.Text)  |  $($R.deps.note)"
+    }
+}
+
 function Update-List {
     $list.Items.Clear()
     $snaps = Get-UndoSnapshots
@@ -341,6 +347,7 @@ function Invoke-QuickUndo([string]$Mode) {
         } else {
             Set-Status ($script:UI.redone -f $r.targetId)
         }
+        Show-DepsNote $r
         Update-List
     } catch {
         Set-Status ($script:UI.fail -f $_.Exception.Message)
@@ -360,6 +367,7 @@ function Restore-Selected {
         $r = Invoke-UndoRestore 'id' $id
         if (-not $r.ok) { Set-Status ($script:UI.restoreFail -f $r.error); return }
         Set-Status ($script:UI.restored -f $r.targetId, $r.preSnapshotId)
+        Show-DepsNote $r
         Update-List
     } catch {
         Set-Status ($script:UI.restoreFail -f $_.Exception.Message)
@@ -442,6 +450,7 @@ function Boot-Rollback {
     if (-not $r.ok) { Set-Status ($script:UI.fail -f $r.error); return }
     if ($r.unchanged) { Set-Status $r.message; return }
     Set-Status ($script:UI.undone -f $r.targetId, $r.preSnapshotId)
+    Show-DepsNote $r
     if ($r.needsRestart) { [void][System.Windows.Forms.MessageBox]::Show($script:UI.restartRequired, 'DSH Undo', 'OK', 'Information') }
     Update-List
 }

--- a/tools/dsh-undo-savepoint-lib.ps1
+++ b/tools/dsh-undo-savepoint-lib.ps1
@@ -44,6 +44,8 @@ $script:UndoFileSpecs = @(
     @{ RootKey = 'profile'; Root = $script:UndoProfileRoot; Name = 'package.json' },
     @{ RootKey = 'profile'; Root = $script:UndoProfileRoot; Name = 'cordis.yml' },
     @{ RootKey = 'profile'; Root = $script:UndoProfileRoot; Name = 'pnpm-workspace.yaml' },
+    @{ RootKey = 'profile'; Root = $script:UndoProfileRoot; Name = 'pnpm-lock.yaml' },
+    @{ RootKey = 'home';    Root = $script:UndoHomeRoot;    Name = 'cordis.patch.yml' },
     @{ RootKey = 'home';    Root = $script:UndoHomeRoot;    Name = 'settings.yaml' },
     @{ RootKey = 'home';    Root = $script:UndoHomeRoot;    Name = '.env' },
     @{ RootKey = 'home';    Root = $script:UndoHomeRoot;    Name = '.credentials.yaml' }
@@ -733,7 +735,56 @@ function Test-UndoNeedsRestart([string[]]$Restored) {
     return $false
 }
 
-function Invoke-UndoRestore([string]$Mode, [string]$Id) {
+# Dependency reconciliation after a restore that touched package.json /
+# pnpm-lock.yaml / pnpm-workspace.yaml. Default is report-only; pnpm runs
+# only when the caller asks for it, and a sync failure never invalidates the
+# restored config files.
+function Invoke-UndoSyncDeps([string[]]$Restored, [bool]$SyncDeps) {
+    $touched = $false
+    foreach ($n in @($Restored)) {
+        if ($n -eq 'profile-package.json' -or $n -eq 'profile-pnpm-lock.yaml' -or $n -eq 'profile-pnpm-workspace.yaml') { $touched = $true; break }
+    }
+    if (-not $touched) { return @{ touched = $false; synced = $false } }
+    if (-not $SyncDeps) {
+        return @{
+            touched = $true
+            synced = $false
+            note = "dependency state may be out of sync - run 'dsh plugin --profile $script:UndoProfileName install' (or 'pnpm install --frozen-lockfile' in $script:UndoProfileRoot)"
+        }
+    }
+    $lockPath = Join-Path $script:UndoProfileRoot 'pnpm-lock.yaml'
+    $args = @('install')
+    if (Test-Path -LiteralPath $lockPath) { $args += '--frozen-lockfile' }
+    $command = "pnpm $($args -join ' ')"
+    $startedAt = [DateTime]::UtcNow
+    Push-Location $script:UndoProfileRoot
+    try {
+        $output = & pnpm @args 2>&1
+        $code = $LASTEXITCODE
+        $ok = ($code -eq 0)
+    } catch {
+        $output = @($_.Exception.Message)
+        $code = 1
+        $ok = $false
+    } finally {
+        Pop-Location
+    }
+    $text = (($output | Out-String) -replace "`r", '')
+    if ($text.Length -gt 4000) { $text = $text.Substring($text.Length - 4000) }
+    return @{
+        touched = $true
+        synced = $ok
+        command = $command
+        profileDir = $script:UndoProfileRoot
+        durationMs = [int]([DateTime]::UtcNow - $startedAt).TotalMilliseconds
+        code = $code
+        stdout = $text
+        stderr = if ($ok) { '' } else { $text }
+        note = if ($ok) { "dependencies synced ($command)" } else { "dependency sync failed ($command): $text" }
+    }
+}
+
+function Invoke-UndoRestore([string]$Mode, [string]$Id, [switch]$SyncDeps) {
     if ($Mode -eq 'undo') {
         $candidates = Get-UndoCandidates
         if (@($candidates).Count -eq 0) { return @{ ok = $false; error = 'nothing to undo' } }
@@ -749,7 +800,8 @@ function Invoke-UndoRestore([string]$Mode, [string]$Id) {
         $remounted = Ensure-UndoMount
         $preflight = Get-UndoPreflight $target.s
         $needsRestart = Test-UndoNeedsRestart $applied.restored
-        return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; preflight = $preflight; targetId = $target.s.id; targetKind = $target.s.kind; targetReason = $target.s.reason; preSnapshotId = $pre.id; remounted = $remounted }
+        $deps = Invoke-UndoSyncDeps $applied.restored $SyncDeps
+        return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; deps = $deps; preflight = $preflight; targetId = $target.s.id; targetKind = $target.s.kind; targetReason = $target.s.reason; preSnapshotId = $pre.id; remounted = $remounted }
     }
     if ($Mode -eq 'redo') {
         $list = Get-UndoSnapshots
@@ -765,7 +817,8 @@ function Invoke-UndoRestore([string]$Mode, [string]$Id) {
         Set-UndoFlag $pre 'consumed' $true
         $preflight = Get-UndoPreflight $pre
         $needsRestart = Test-UndoNeedsRestart $applied.restored
-        return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; preflight = $preflight; targetId = $pre.id; remounted = $false }
+        $deps = Invoke-UndoSyncDeps $applied.restored $SyncDeps
+        return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; deps = $deps; preflight = $preflight; targetId = $pre.id; remounted = $false }
     }
     # mode 'id'
     $target = Get-UndoSnapshotById $Id
@@ -775,7 +828,8 @@ function Invoke-UndoRestore([string]$Mode, [string]$Id) {
     $remounted = Ensure-UndoMount
     $preflight = Get-UndoPreflight $target
     $needsRestart = Test-UndoNeedsRestart $applied.restored
-    return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; preflight = $preflight; targetId = $target.id; targetKind = $target.kind; targetReason = $target.reason; preSnapshotId = $pre.id; remounted = $remounted }
+    $deps = Invoke-UndoSyncDeps $applied.restored $SyncDeps
+    return @{ ok = $true; restored = $applied.restored; missing = $applied.missing; notes = $applied.notes; needsRestart = $needsRestart; deps = $deps; preflight = $preflight; targetId = $target.id; targetKind = $target.kind; targetReason = $target.reason; preSnapshotId = $pre.id; remounted = $remounted }
 }
 
 function Remove-UndoSnapshot([string]$Id) {

--- a/tools/dsh-undo.ps1
+++ b/tools/dsh-undo.ps1
@@ -3,10 +3,11 @@
 # Usage:
 #   .\dsh-undo.ps1 snapshot [-Label "before installing X"]   # manual save
 #   .\dsh-undo.ps1 undo                                       # undo the last change
+#   .\dsh-undo.ps1 undo -SyncDeps                             # undo and rebuild node_modules from the restored lockfile
 #   .\dsh-undo.ps1 redo                                       # redo the last undo
 #   .\dsh-undo.ps1 list                                       # visual list
 #   .\dsh-undo.ps1 diff -Id <id|latest>
-#   .\dsh-undo.ps1 restore -Id <id|latest> [-Force]           # restore a fixed version
+#   .\dsh-undo.ps1 restore -Id <id|latest> [-Force] [-SyncDeps]
 #   .\dsh-undo.ps1 remove -Id <id>                            # delete a snapshot
 #   .\dsh-undo.ps1 prune [-KeepAuto 20]
 #   .\dsh-undo.ps1 status
@@ -22,7 +23,8 @@ param(
     [string]$Label = '',
     [string]$Id = '',
     [int]$KeepAuto = 20,
-    [switch]$Force
+    [switch]$Force,
+    [switch]$SyncDeps
 )
 
 $ErrorActionPreference = 'Stop'
@@ -35,7 +37,7 @@ switch ($Command) {
         Write-Host "Manual snapshot $($s.id) created ($(@($s.files).Count) file(s), reason: $reason). Store: $((Get-UndoSettings).manualDir)"
     }
     'undo' {
-        $r = Invoke-UndoRestore 'undo' ''
+        $r = Invoke-UndoRestore 'undo' '' -SyncDeps:$SyncDeps
         if (-not $r.ok) { Write-Host "undo failed: $($r.error)"; exit 1 }
         if ($r.unchanged) { Write-Host $r.message; exit 0 }
         Write-Host "Undone: restored $($r.targetId) ($($r.targetKind): $($r.targetReason))"
@@ -44,6 +46,13 @@ switch ($Command) {
         if ($r.remounted) { Write-Host 'dsh-undo mount re-ensured in cordis.patch.yml' }
         if ($r.missing -and @($r.missing).Count -gt 0) { Write-Host "Not restored: $($r.missing -join ', ')" }
         if ($r.needsRestart) { Write-Host 'NOTE: a restart of DSH is required for the restored state to take effect.' }
+        if ($r.deps.touched) {
+            if ($r.deps.synced) { Write-Host "Dependencies synced: $($r.deps.command)" }
+            else {
+                Write-Host "WARNING $($r.deps.note)"
+                Write-Host 'Restored config files are in place; re-run with -SyncDeps to rebuild dependencies automatically.'
+            }
+        }
         if ($r.preflight -and @($r.preflight.missing).Count -gt 0) {
             Write-Host "WARNING Cross-machine preflight: not resolvable on this machine: $($r.preflight.missing -join ', ')"
             Write-Host 'DSH may fail to start after restore - install them first, or run: dsh-undo.ps1 safe-mode -Label on'
@@ -51,12 +60,19 @@ switch ($Command) {
         foreach ($n in @($r.notes)) { Write-Host "Note: $n" }
     }
     'redo' {
-        $r = Invoke-UndoRestore 'redo' ''
+        $r = Invoke-UndoRestore 'redo' '' -SyncDeps:$SyncDeps
         if (-not $r.ok) { Write-Host "redo failed: $($r.error)"; exit 1 }
         Write-Host "Redone: re-applied $($r.targetId)"
         Write-Host "Files: $($r.restored -join ', ')"
         if ($r.missing -and @($r.missing).Count -gt 0) { Write-Host "Not restored: $($r.missing -join ', ')" }
         if ($r.needsRestart) { Write-Host 'NOTE: a restart of DSH is required for the restored state to take effect.' }
+        if ($r.deps.touched) {
+            if ($r.deps.synced) { Write-Host "Dependencies synced: $($r.deps.command)" }
+            else {
+                Write-Host "WARNING $($r.deps.note)"
+                Write-Host 'Restored config files are in place; re-run with -SyncDeps to rebuild dependencies automatically.'
+            }
+        }
         foreach ($n in @($r.notes)) { Write-Host "Note: $n" }
     }
     'list' {
@@ -83,7 +99,7 @@ switch ($Command) {
     'restore' {
         if ([string]::IsNullOrEmpty($Id)) { throw 'restore requires -Id <id|latest>' }
         $targetId = if ($Id -eq 'latest') { @(Get-UndoSnapshots)[0].id } else { $Id }
-        $r = Invoke-UndoRestore 'id' $targetId
+        $r = Invoke-UndoRestore 'id' $targetId -SyncDeps:$SyncDeps
         if (-not $r.ok) { Write-Host "restore failed: $($r.error)"; exit 1 }
         Write-Host "Restored $($r.targetId) ($($r.targetKind): $($r.targetReason))"
         Write-Host "Files: $($r.restored -join ', ')"
@@ -91,6 +107,13 @@ switch ($Command) {
         if ($r.remounted) { Write-Host 'dsh-undo mount re-ensured in cordis.patch.yml' }
         if ($r.missing -and @($r.missing).Count -gt 0) { Write-Host "Not restored: $($r.missing -join ', ')" }
         if ($r.needsRestart) { Write-Host 'NOTE: a restart of DSH is required for the restored state to take effect.' }
+        if ($r.deps.touched) {
+            if ($r.deps.synced) { Write-Host "Dependencies synced: $($r.deps.command)" }
+            else {
+                Write-Host "WARNING $($r.deps.note)"
+                Write-Host 'Restored config files are in place; re-run with -SyncDeps to rebuild dependencies automatically.'
+            }
+        }
         if ($r.preflight -and @($r.preflight.missing).Count -gt 0) {
             Write-Host "WARNING Cross-machine preflight: not resolvable on this machine: $($r.preflight.missing -join ', ')"
             Write-Host 'DSH may fail to start after restore - install them first, or run: dsh-undo.ps1 safe-mode -Label on'

--- a/tools/smoke-test.mjs
+++ b/tools/smoke-test.mjs
@@ -679,6 +679,52 @@ console.log('   ', out.split('\n')[0]);
 check(out.includes('Restored snapshot'), 'undo proceeds when the last turn is closed (not busy)');
 await rm(root17, { recursive: true, force: true });
 
+console.log('== 24. lockfile + home patch snapshots and dependency reconciliation ==');
+const root18 = await mkdtemp(join(tmpdir(), 'dsh-undo-test18-'));
+const home18 = join(root18, 'home'), profile18 = join(root18, 'profile'), snap18 = join(root18, 'snaps');
+await mkdir(home18, { recursive: true }); await mkdir(profile18, { recursive: true });
+await writeFile(join(home18, 'settings.yaml'), 'model: x\n');
+await writeFile(join(home18, 'cordis.patch.yml'), '# home patch\n[]\n');
+await writeFile(join(profile18, 'cordis.patch.yml'), '# patch\n[]\n');
+await writeFile(join(profile18, 'package.json'), '{"name":"test","v":1}\n');
+await writeFile(join(profile18, 'pnpm-workspace.yaml'), 'packages:\n  - .\n');
+await writeFile(join(profile18, 'pnpm-lock.yaml'), 'lockfileVersion: "9.0"\nv: 1\n');
+const tools18 = new Map();
+const ctx18 = {
+  tools: { register: (t) => { tools18.set(t.name, t); return () => { }; } },
+  systemPrompt: { section: () => () => { } }, get: () => undefined,
+  effect: (fn) => { const d = fn(); return d ?? (() => { }); }, logger: { info: () => { }, warn: () => { } },
+};
+apply(ctx18, { manualDir: join(snap18, 'manual'), autoDir: join(snap18, 'auto'), homeDir: home18, profileDir: profile18, profileName: 'web', watch: false, pluginDirs: [] });
+await new Promise((r) => setTimeout(r, 300));
+const run18 = async (name, args) => (await tools18.get(name).execute(args, {}));
+await run18('undo_snapshot', { reason: 'lock-v1' });
+const m18dir = (await readdir(join(snap18, 'manual'))).find((d) => !d.startsWith('.'));
+const m18 = JSON.parse(await readFile(join(snap18, 'manual', m18dir, 'manifest.json'), 'utf8'));
+check(m18.files.some((f) => f.name === 'profile-pnpm-lock.yaml'), 'snapshot includes profile pnpm-lock.yaml');
+check(m18.files.some((f) => f.name === 'home-cordis.patch.yml'), 'snapshot includes home cordis.patch.yml');
+await writeFile(join(profile18, 'package.json'), '{"name":"test","v":2}\n');
+await writeFile(join(profile18, 'pnpm-lock.yaml'), 'lockfileVersion: "9.0"\nv: 2\n');
+await run18('undo_snapshot', { reason: 'lock-v2' });
+out = await run18('undo_restore', { mode: 'undo' });
+check((await readFile(join(profile18, 'pnpm-lock.yaml'), 'utf8')).includes('v: 1'), 'undo restores pnpm-lock.yaml bytes');
+check(out.includes('dependency state may be out of sync'), 'default restore reports dependency drift without running pnpm');
+// fake pnpm on PATH: verify the explicit sync path and its command line
+const bin18 = join(root18, 'bin');
+await mkdir(bin18, { recursive: true });
+const marker18 = join(root18, 'pnpm-calls.txt');
+process.env.FAKE_PNPM_LOG = marker18;
+await writeFile(join(bin18, 'pnpm.cmd'), '@echo off\r\necho %*>> "%FAKE_PNPM_LOG%"\r\nexit /b 0\r\n');
+const oldPath18 = process.env.PATH;
+process.env.PATH = `${bin18};${oldPath18}`;
+await writeFile(join(profile18, 'package.json'), '{"name":"test","v":3}\n');
+await run18('undo_snapshot', { reason: 'lock-v3' });
+out = await run18('undo_restore', { mode: 'undo', sync_deps: true });
+process.env.PATH = oldPath18;
+check(out.includes('Dependencies synced'), 'sync_deps reports successful pnpm run');
+check((await readFile(marker18, 'utf8')).includes('install --frozen-lockfile'), 'sync ran pnpm install --frozen-lockfile');
+await rm(root18, { recursive: true, force: true });
+
 await rm(root, { recursive: true, force: true });
 console.log(`\n== RESULT: ${pass} passed, ${fail} failed ==`);
 process.exit(fail > 0 ? 1 : 0);


### PR DESCRIPTION
## Related issue

`Fixes #8`

## Summary

Rollback previously restored only part of what `dsh plugin add/update/remove` mutates: `pnpm-lock.yaml` was never snapshotted, `$DSH_HOME/cordis.patch.yml` was missing, and `node_modules` was never reconciled. This PR makes the snapshot set cover the full boot-critical state and adds an opt-in dependency sync after restore.

## Changes

- Snapshot config files now include:
  - `profiles/<name>/pnpm-lock.yaml`
  - `$DSH_HOME/cordis.patch.yml`
- Restore is unchanged by default except for a new report field: when the restore touched `package.json` / `pnpm-lock.yaml` / `pnpm-workspace.yaml`, the result says `node_modules` may be out of sync and prints the rebuild command.
- Opt-in dependency sync:
  - chat tool `undo_restore`: `sync_deps: true`
  - REST `/api/undo/undo|redo|restore`: `syncDeps: true`
  - offline CLI: `dsh-undo.ps1 undo|redo|restore -SyncDeps`
  - runs `pnpm install --frozen-lockfile` (plain `pnpm install` when no lockfile exists)
  - a failed install leaves the restored config files in place and is reported, never treated as a failed restore
- GUI shows the dependency-drift note after quick undo, selected restore, and boot-rollback.

## Verification

- `npm test` with `DSH_ROOT` set: smoke **112/112**, watcher e2e **10/10**, home-resolution **2/2**.
- New smoke coverage:
  - manifest contains `profile-pnpm-lock.yaml` and `home-cordis.patch.yml`
  - undo restores lockfile bytes
  - default restore reports dependency drift without running pnpm
  - `sync_deps: true` runs `pnpm install --frozen-lockfile`
- Real end-to-end check on a temporary `DSH_HOME`:
  - `dsh plugin --profile web add dsh-safe-delete@0.1.12`
  - snapshot → `dsh plugin update dsh-safe-delete --latest` (manifest/lock/installed all become 0.2.1)
  - offline `dsh-undo.ps1 restore -Id <id> -Force -SyncDeps`
  - after restore: `package.json` 0.1.12, `pnpm-lock.yaml` 0.1.12, installed package 0.1.12

## Notes / trade-offs

- pnpm is not run automatically: it can hit the network, lifecycle scripts, and Windows file locks; the default is report-only.
- A failed `--frozen-lockfile` run is not silently downgraded to a plain install.
- Sensitive-file handling (redact + local vault) is untouched.
