### PR TITLE
fix(webui): 局外 undo-server 补齐 /api/undo/note 路由

### DIFF
--- a/tools/undo-server.mjs
+++ b/tools/undo-server.mjs
@@ -37,6 +37,7 @@ import {
   restore,
   createSnapshot,
   removeSnapshot,
+  setSnapshotMeta,
   pruneAuto,
   exportSnapshots,
   importSnapshots,
@@ -238,6 +239,11 @@ const server = createServer(async (req, res) => {
       if (method === 'POST' && path === '/api/undo/remove') {
         const body = await readJson(req);
         return send(res, 200, { ok: true, ...await removeSnapshot(cfg, body?.id) });
+      }
+      if (method === 'POST' && path === '/api/undo/note') {
+        const body = await readJson(req);
+        const r = await setSnapshotMeta(cfg, body?.id ?? '', body ?? {});
+        return send(res, r.ok ? 200 : 404, { ok: r.ok, ...r });
       }
       if (method === 'POST' && path === '/api/undo/prune') {
         const list = await listSnapshots(cfg);


### PR DESCRIPTION
# fix(webui): 局外 undo-server 补齐 /api/undo/note 路由

> Closes #18

## 背景

局外 undo-server(`tools/undo-server.mjs`,DSH 挂掉时使用)缺少 `POST /api/undo/note` 路由,导致局外 WebUI 编辑快照备注/标签时报 `unknown route /api/undo/note`。详情见对应 issue。

## 改动

`tools/undo-server.mjs`(+6 行,与局内 `lib/index.js` 同款实现):

1. import 列表增加 `setSnapshotMeta`
2. 在 `/api/undo/remove` 之后新增路由:

```js
if (method === 'POST' && path === '/api/undo/note') {
  const body = await readJson(req);
  const r = await setSnapshotMeta(cfg, body?.id ?? '', body ?? {});
  return send(res, r.ok ? 200 : 404, { ok: r.ok, ...r });
}
```

## 验证

- 局外服务器写入备注/标签 → 返回 `{ok:true,…}`,快照列表读回一致
- 无效快照 id → 返回 404
- 与局内 `/api/undo/note` 行为一致(同一 `setSnapshotMeta` 实现)
