### PR TITLE
fix(core): 恢复敏感文件后强制 owner-only 权限(0600)

### DIFF
--- a/lib/core.mjs
+++ b/lib/core.mjs
@@ -1250,6 +1250,11 @@ async function applySnapshot(cfg, snap) {
     const tmp = `${target}.undo-tmp`;
     await fs.writeFile(tmp, buf);
     await renameWithRetry(tmp, target);
+    // #17: 恢复的敏感文件必须保持 owner-only(0600),否则 credentials-local
+    // 在 POSIX 上拒绝启动(默认 umask 会让 writeFile 写出 0644)。
+    if (SENSITIVE_DESTS.has(file.name)) {
+      try { await fs.chmod(target, 0o600); } catch { /* 平台不支持则忽略 */ }
+    }
     hashes.set(file.name, sha1Hex(buf));
     restored.push(file.name);
     if (sensitiveNote) notes.push(sensitiveNote);


### PR DESCRIPTION
# fix(core): 恢复敏感文件后强制 owner-only 权限(0600)

> Closes #17

## 问题

`applySnapshot()` 恢复文件时用 `writeFile(tmp) + rename(tmp, target)`,新建的临时文件按默认 umask 得到 **0644**。`~/.dsh/.credentials.yaml` 等敏感文件恢复后变成 0644,而 `@deepseek-ai/dsh-credentials-local` 在 POSIX 上强制要求 owner-only(0600),导致 DSH 下次启动崩溃。

## 改动

`lib/core.mjs` 的 `applySnapshot()` 文件恢复循环,`renameWithRetry` 之后对 `SENSITIVE_DESTS` 内的文件补 chmod:

```js
if (SENSITIVE_DESTS.has(file.name)) {
  try { await fs.chmod(target, 0o600); } catch { /* 平台不支持则忽略 */ }
}
```

- 只影响敏感文件(`home-.env` / `profile-.env` / `home-.credentials.yaml`),普通文件权限行为不变
- chmod 用 try/catch 包裹:Windows 等语义受限平台静默跳过,绝不阻断恢复流程

## 验证

隔离环境(D SH_HOME=/tmp)实测:
1. `.credentials.yaml` 初始 0600 → 建快照
2. 篡改为内容变更 + 0644
3. `restore` 恢复该快照
4. 恢复后:内容正确还原、**权限回到 0600** ✓

## 影响面

- 快照格式不变、状态机不变、只读路径不变
- 修复前:任何含凭据的恢复在 POSIX 上都会让下次 DSH 启动失败(issue #17 实锤)
