### PR TITLE
fix(host): 三个聊天工具 parameters 适配 dsh-tools value-schema 平铺格式

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -489,13 +489,12 @@ export function apply(ctx, config = {}) {
   safeEffect(() => registerToolOnce(defineTool({
     name: 'undo_doctor',
     description: 'Run a one-click diagnostic of the snapshot store: store dirs writable, blob integrity (missing/orphan), settings file health, and snapshot counts. Returns a structured report with ok/warn/error checks. Use when the user asks to diagnose, check health, or "is my undo snapshots okay".',
+    // 参数必须是「属性映射」形式（value schema 平铺），与 undo_scan 等一致；
+    // dsh-tools 0.0.1-rc.1 的 defineTool 拒绝 { type:'object', properties } 包装（M1 修复）。
     parameters: {
-      type: 'object',
-      properties: {
-        include_fix_hints: {
-          type: 'boolean',
-          description: 'Include actionable fix hints for any warn/error checks (default true).',
-        },
+      include_fix_hints: {
+        type: 'boolean',
+        description: 'Include actionable fix hints for any warn/error checks (default true).',
       },
     },
     output: TEXT_OUTPUT,
@@ -531,12 +530,9 @@ export function apply(ctx, config = {}) {
     name: 'undo_message',
     description: 'Roll back the file changes made by a message batch (reverse order): restore files to their before-content, or delete newly-created files. Use after undo_message_list to pick a batch id. Does NOT touch the DSH session store (no public delete API); it only restores the workspace files.',
     parameters: {
-      type: 'object',
-      properties: {
-        message_id: {
-          type: 'string',
-          description: 'Batch id from undo_message_list, or "latest" (default) for the most recent batch.',
-        },
+      message_id: {
+        type: 'string',
+        description: 'Batch id from undo_message_list, or "latest" (default) for the most recent batch.',
       },
     },
     output: TEXT_OUTPUT,
@@ -552,10 +548,7 @@ export function apply(ctx, config = {}) {
     name: 'undo_compact',
     description: 'Garbage-collect orphan blob files (blobs not referenced by any snapshot or message batch) and leftover .tmp files. Frees disk space without touching any live snapshot data.',
     parameters: {
-      type: 'object',
-      properties: {
-        dry_run: { type: 'boolean', description: 'Only report what would be removed without deleting anything (default false).' },
-      },
+      dry_run: { type: 'boolean', description: 'Only report what would be removed without deleting anything (default false).' },
     },
     output: TEXT_OUTPUT,
     isConcurrencySafe: () => true,

--- a/tools/smoke-test.mjs
+++ b/tools/smoke-test.mjs
@@ -60,6 +60,12 @@ const run = async (name, args) => {
   if (!t) throw new Error(`tool not registered: ${name}`);
   return await t.execute(args, {});
 };
+// M1 回归：全部文档化工具必须通过真实 defineTool 注册成功（dsh-tools 拒绝
+// { type:'object', properties } 包装时这里会先抓到，不再静默降级）。
+check(tools.has('undo_doctor'), 'M1: undo_doctor registered (parameters schema compatible)');
+check(tools.has('undo_message'), 'M1: undo_message registered (parameters schema compatible)');
+check(tools.has('undo_compact'), 'M1: undo_compact registered (parameters schema compatible)');
+check(tools.has('undo_message_list') && tools.has('undo_scan') && tools.has('undo_safe_mode'), 'M1: undo_message_list / undo_scan / undo_safe_mode registered');
 const cur = async (f) => readFile(join(profile, f), 'utf8');
 const set = async (f, v) => writeFile(join(profile, f), v);
 // Windows 上 fs.rm 偶发 ENOTEMPTY（杀软/索引器短暂占用目录句柄），清理时重试几次


### PR DESCRIPTION
# fix(host): 三个聊天工具 parameters 适配 dsh-tools value-schema 平铺格式

> Closes #20

## 问题

`undo_doctor` / `undo_message` / `undo_compact` 三个聊天工具声明 `parameters: { type: 'object', properties: { … } }`。dsh-tools 的 schema 编译器把 `parameters` 当作 **value-schema 属性映射表**解析:`type` 键被当作属性名、其值 `'object'` 不是合法 value-schema → `defineTool` 抛 `must be an object of value schemas` → 工具**静默不注册**(无报错、不可用)。

- 本机实测(当前 `@deepseek-ai/dsh-tools@0.1.1-rc.2`,schema 校验位于 lib/index.js 的 `property-map` 分支):旧格式仍被拒
- 其余工具不受影响,说明仅这三个的声明方式与 dsh-tools 不兼容

## 改动

`lib/index.js`:三个工具的 `parameters` 从 `{ type:'object', properties:{…} }` 改为**平铺的 value-schema 映射**(与 `undo_scan` 等已有工具一致),并加注释说明。

`tools/smoke-test.mjs`:新增 M1 回归断言——全部文档化工具必须通过真实注册(`tools.has('undo_doctor')` 等),防止未来静默降级再次发生。

## 验证

- 仓库自带测试:`node tools/smoke-test.mjs` → **212 passed, 0 failed**(含新增注册断言)
- DSH 运行会话中三个工具正常注册可用

## 影响面

- 仅改三个工具的 `parameters` 声明与测试,无运行时行为变化
