### PR TITLE
fix(zip): 导入加固——条目标名白名单校验 + 解压大小上限(防 zip-slip / 炸弹)

### DIFF
--- a/lib/core.mjs
+++ b/lib/core.mjs
@@ -2065,14 +2065,31 @@ async function exportSnapshots(cfg, password) {
     return { ok: false, error: String(error?.message ?? error) };
   }
 }
+/** 导入条目标名安全校验（H1 加固）：拒绝 .. / 绝对路径 / 非法 blob 名 / 非法快照 id。
+ *  blob 文件名必须是 40 位 hex（sha1；PS 端 Get-FileHash 大写、Node 端小写，故大小写不敏感，
+ *  写入时保留原大小写，保证与 manifest 里记录的 hash 字符串一致）。快照 id 必须匹配 makeId 格式。 */
+const BLOB_NAME_RE = /^[0-9a-f]{40}$/i;
+const SNAP_ID_RE = /^\d{8}-\d{6}-[0-9a-f]{4}$/i;
+function assertSafeZipEntry(name, what) {
+  if (typeof name !== 'string' || name === ''
+    || name.includes('..') || name.startsWith('/') || name.startsWith('\\')
+    || /^[A-Za-z]:/.test(name)) {
+    throw new Error(`unsafe ${what} in import zip: ${JSON.stringify(name ?? '(empty)')}`);
+  }
+}
+
 async function importSnapshots(cfg, zipPath, password) {
   if (!zipPath || !(await pathExists(zipPath))) return { ok: false, error: `file not found: ${zipPath ?? '(none)'}` };
   let imported = 0;
   let skipped = 0;
+  let rejected = 0;
   try {
     // V0.4.0 P4：支持可选加密导出。检测到加密头时要求密码；解密到临时文件再解析。
     let entries;
     const raw = await fs.readFile(zipPath);
+    // H2 加固：整体体积上限（防 zip 炸弹把宿主进程内存打爆）。
+    const MAX_ZIP_BYTES = 1024 * 1024 * 1024;
+    if (raw.length > MAX_ZIP_BYTES) return { ok: false, error: `import zip too large (${raw.length} bytes > ${MAX_ZIP_BYTES})` };
     if (isEncryptedExport(raw)) {
       if (!password || !String(password).length) return { ok: false, error: '该导出已加密，需提供密码才能导入。', code: 'encrypted' };
       let dec;
@@ -2090,7 +2107,9 @@ async function importSnapshots(cfg, zipPath, password) {
       const destBlob = blobDir(cfg);
       await fs.mkdir(destBlob, { recursive: true });
       for (const e of blobs) {
+        assertSafeZipEntry(e.name, 'blob entry');
         const name = e.name.slice('blobs/'.length).normalize('NFC');
+        if (!BLOB_NAME_RE.test(name)) { rejected++; continue; } // 非 sha1 命名的条目一律跳过（含穿越尝试）
         if (!(await pathExists(join(destBlob, name)))) {
           await fs.writeFile(join(destBlob, name), e.data);
         }
@@ -2101,6 +2120,7 @@ async function importSnapshots(cfg, zipPath, password) {
     const snapDirs = new Set();
     for (const e of entries) {
       if (!e.name.endsWith('/manifest.json')) continue;
+      assertSafeZipEntry(e.name, 'snapshot entry');
       const dir = e.name.slice(0, -'/manifest.json'.length);
       const parts = dir.split('/');
       if (parts.length >= 2) snapDirs.add(dir); // 形如 manual/<id> 或 auto/<id>
@@ -2112,6 +2132,7 @@ async function importSnapshots(cfg, zipPath, password) {
         try { kind = (JSON.parse(mf.data.toString('utf8'))).kind ?? 'auto'; } catch { /* default auto */ }
       }
       const id = dir.split('/').pop().normalize('NFC');
+      if (!SNAP_ID_RE.test(id)) { rejected++; continue; } // 非法快照 id（含 .. 穿越尝试）
       const dest = (kind === 'manual' ? cfg.manualDir : cfg.autoDir);
       if (await pathExists(join(dest, id))) { skipped++; continue; }
       const destDir = join(dest, id);
@@ -2119,13 +2140,14 @@ async function importSnapshots(cfg, zipPath, password) {
       // 将该目录名下（不含深层子目录？快照目录是平的）所有条目写入
       for (const e of entries) {
         if (!e.name.startsWith(`${dir}/`)) continue;
+        assertSafeZipEntry(e.name, 'snapshot file entry');
         const rel = e.name.slice(`${dir}/`.length);
-        if (!rel || rel.includes('/')) continue; // 只取该快照目录下的顶层文件
+        if (!rel || rel.includes('/') || rel.includes('..')) continue; // 只取该快照目录下的顶层文件
         await fs.writeFile(join(destDir, rel.normalize('NFC')), e.data);
       }
       imported++;
     }
-    return { ok: true, imported, skipped, source: zipPath };
+    return { ok: true, imported, skipped, rejected, source: zipPath };
   } catch (error) {
     return { ok: false, error: String(error?.message ?? error) };
   }

--- a/lib/zip.mjs
+++ b/lib/zip.mjs
@@ -117,6 +117,12 @@ export async function writeZip(zipPath, files) {
 }
 
 /**
+ * 单条解压大小上限（H2 加固）：解压前先校验声明大小，再用 maxOutputLength
+ * 限制实际分配，防 zip 炸弹把宿主进程内存打爆。
+ */
+export const MAX_ENTRY_BYTES = 64 * 1024 * 1024;
+
+/**
  * 读一个标准 ZIP（deflate/store），返回 [{name, data:Buffer}]。
  * 兼容 PowerShell Expand-Archive / archiver / unzip 产物。
  * @param {string} zipPath 目标 .zip 路径
@@ -144,6 +150,9 @@ export async function readZip(zipPath) {
     const commentLen = buf.readUInt16LE(off + 32);
     const localOffset = buf.readUInt32LE(off + 42);
     const name = buf.toString('utf8', off + 46, off + 46 + nameLen).normalize('NFC').replace(/\\/g, '/');
+    // H2：解压前先拒绝声明过大的条目；stored 条目同理（压缩比 1:1，直接超限）。
+    if (usize > MAX_ENTRY_BYTES) throw new Error(`zip entry too large: ${name} (${usize} bytes > ${MAX_ENTRY_BYTES})`);
+    if (csize > buf.length) throw new Error(`zip entry corrupt: ${name} (compressed size ${csize} > file size ${buf.length})`);
     // 从 local header 读数据（跳过 30 字节头 + name + extra）
     const lhSig = buf.readUInt32LE(localOffset);
     if (lhSig !== 0x04034b50) throw new Error('bad local header signature at ' + localOffset);
@@ -152,7 +161,7 @@ export async function readZip(zipPath) {
     const dataStart = localOffset + 30 + lNameLen + lExtraLen;
     const comp = buf.subarray(dataStart, dataStart + csize);
     let data;
-    if (method === 8) data = inflateRawSync(comp);
+    if (method === 8) data = inflateRawSync(comp, { maxOutputLength: MAX_ENTRY_BYTES });
     else if (method === 0) data = Buffer.from(comp);
     else throw new Error(`unsupported compression method ${method} for ${name}`);
     if (data.length !== usize) throw new Error(`size mismatch for ${name}`);


### PR DESCRIPTION
# fix(zip): 导入加固——条目标名白名单校验 + 解压大小上限

> Closes #24, Closes #25

## 背景

导入 ZIP(`undo_import` / 局外 WebUI)存在两个安全问题:

- **#24 zip-slip**:`importSnapshots` 把条目名直接拼进路径写入,`blobs/../../...` 可越权创建任意路径文件
- **#25 解压炸弹**:`readZip` 对 deflate 条目无限流解压,声明大 `usize` 的高压缩条目可打爆宿主内存(OOM)

## 改动

**`lib/zip.mjs`**
- 新增 `MAX_ENTRY_BYTES = 64MB` 单条上限
- 解压前校验:`usize > MAX_ENTRY_BYTES` 拒绝、`csize > buf.length` 视为损坏
- `inflateRawSync(comp, { maxOutputLength: MAX_ENTRY_BYTES })`

**`lib/core.mjs`(`importSnapshots`)**
- 新增 `assertSafeZipEntry`(拒绝 `..` / 绝对路径 / 盘符)+ `BLOB_NAME_RE`(40 位 sha1 hex)+ `SNAP_ID_RE`(快照 id 格式)
- blob 条目非 sha1 名一律跳过(含穿越尝试)、快照目录 id 不合法跳过、快照文件条目逐条校验
- 整体 zip 体积上限 1GB
- 结果新增 `rejected` 计数

## 验证

隔离环境实测:
- zip-slip 探针 → `unsafe blob entry in import zip`,**无文件写出** ✓
- 70MB 声明炸弹 → `zip entry too large (73400320 > 67108864)`,服务器存活 ✓
- 合法 ZIP → `imported:1, rejected:0` 正常 ✓
