### PR TITLE
fix(webui): 双端 API 加 Origin 校验,防跨站 CSRF(含端口比对)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -930,6 +930,20 @@ export function apply(ctx, config = {}) {
           const url = new URL(req.url ?? '/', 'http://dsh.local');
           const path = url.pathname;
           const method = (req.method ?? 'GET').toUpperCase();
+          // M2 加固：跨站 CSRF 防护——浏览器跨源 POST 必带 Origin，与 Host 不符即拒；
+          // 无 Origin（本机脚本/curl）放行。同源 UI 请求 Origin.host === Host，不受影响。
+          const origin = req.headers?.origin;
+          if (origin) {
+            let ok = false;
+            try {
+              const o = new URL(origin);
+              const host = String(req.headers?.host ?? '');
+              ok = o.host === host && (o.protocol === 'http:' || o.protocol === 'https:');
+            } catch { ok = false; }
+            if (!ok) {
+              return send(res, 403, { ok: false, error: { code: 'forbidden', message: 'cross-origin request rejected' } });
+            }
+          }
           if (method === 'GET' && path === '/api/undo/list') {
             const snapshots = (await listSnapshots(cfg)).map((s) => {
               const { _dir, _store, ...rest } = s;

--- a/tools/undo-server.mjs
+++ b/tools/undo-server.mjs
@@ -174,6 +174,22 @@ const server = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
     const path = url.pathname;
     const method = (req.method ?? 'GET').toUpperCase();
+    // M2 加固：跨站 CSRF 防护——浏览器发起的跨源请求必带 Origin，与 Host 不符即拒。
+    // 无 Origin 的请求（curl / 本机脚本）放行，保持离线工具可用性。
+    const origin = req.headers?.origin;
+    if (origin) {
+      let ok = false;
+      try {
+        const o = new URL(origin);
+        const host = String(req.headers?.host ?? '');
+        ok = o.host === host && (o.protocol === 'http:' || o.protocol === 'https:');
+      } catch { ok = false; }
+      if (!ok) {
+        res.writeHead(403, { 'content-type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ ok: false, error: { code: 'forbidden', message: 'cross-origin request rejected' } }));
+        return;
+      }
+    }
     if (path.startsWith('/api/')) {
       if (method === 'GET' && path === '/api/undo/status') {
         const list = await listSnapshots(cfg);


### PR DESCRIPTION
# fix(webui): 双端 API 加 Origin 校验,防跨站 CSRF

> Closes #27

## 改动

`lib/index.js`(局内)与 `tools/undo-server.mjs`(局外)的请求入口,对带 `Origin` 头的请求校验 `Origin.host === Host`(含端口),不符返回 403;无 Origin(curl/本机脚本)放行。

两处实现一致:

```js
const origin = req.headers?.origin;
if (origin) {
  let ok = false;
  try {
    const o = new URL(origin);
    const host = String(req.headers?.host ?? '');
    ok = o.host === host && (o.protocol === 'http:' || o.protocol === 'https:');
  } catch { ok = false; }
  if (!ok) { /* 403 */ }
}
```

## 验证

隔离服务器实测:
- evil Origin → 403
- **不同端口 Origin → 403**(顺带修复"只验 hostname 不验端口"的缺口)
- 无 Origin → 放行
- `127.0.0.1` / `localhost` 同源(含端口一致)→ 200
