### PR TITLE
fix(webui): 局外导出/导入透传密码,加密开关生效

### DIFF
--- a/tools/undo-server.mjs
+++ b/tools/undo-server.mjs
@@ -266,11 +266,13 @@ const server = createServer(async (req, res) => {
         return send(res, 200, { ok: true, pruned: await pruneAuto(cfg, list) });
       }
       if (method === 'POST' && path === '/api/undo/export') {
-        return send(res, 200, { ok: true, ...await exportSnapshots(cfg) });
+        const body = await readJson(req);
+        // M3 修复：把 WebUI 收集的密码透传给导出（否则加密开关是摆设）。
+        return send(res, 200, { ok: true, ...await exportSnapshots(cfg, body?.password ?? '') });
       }
       if (method === 'POST' && path === '/api/undo/import') {
         const body = await readJson(req);
-        return send(res, 200, { ok: true, ...await importSnapshots(cfg, body?.path) });
+        return send(res, 200, { ok: true, ...await importSnapshots(cfg, body?.path, body?.password ?? '') });
       }
       if (method === 'POST' && path === '/api/undo/pick-dir') { return send(res, 200, { ok: true, ...await pickDirectory() }); }
       if (method === 'POST' && path === '/api/undo/pick-file') { return send(res, 200, { ok: true, ...await pickFile() }); }


### PR DESCRIPTION
# fix(webui): 局外导出/导入透传密码,加密开关生效

> Closes #29

## 改动

`tools/undo-server.mjs` 的 export/import handler 读取 body 并把 `password` 透传给 `exportSnapshots` / `importSnapshots`,与局内 `lib/index.js` 一致。

## 验证

隔离服务器实测:
- 带密码导出 → `encrypted: true` ✓
- 无密码导入加密 ZIP → `该导出已加密，需提供密码才能导入。` ✓
- 正确密码导入 → 成功 ✓
- 错误密码导入 → `解密失败（密码错误或文件损坏）。` ✓
