### PR TITLE
docs: README 修正 CLI 文件名(dsh-undo.ps1) + desktop 模板自查找修复

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -139,15 +139,15 @@ mklink /J "<your-dsh-install>\node_modules\dsh-undo-savepoint" "D:\dsh\plugins\d
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint-gui.ps1"
 
 # CLI
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" list
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" snapshot -Label "reason"
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo -SyncDeps
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" redo
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force -SyncDeps
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" remove -Id <id>
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" prune -KeepAuto 20
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" list
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" snapshot -Label "reason"
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" undo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" undo -SyncDeps
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" redo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" restore -Id <id> -Force
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" restore -Id <id> -Force -SyncDeps
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" remove -Id <id>
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" prune -KeepAuto 20
 
 # Safe plugin install (auto snapshots before/after; auto-rollback on failure)
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-plugin.ps1" add <package>

--- a/README.md
+++ b/README.md
@@ -201,15 +201,15 @@ explorer "$dshHome\profiles\web\node_modules\dsh-undo-savepoint\tools"
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint-gui.ps1"
 
 # 命令行
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" list
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" snapshot -Label "原因"
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" undo -SyncDeps
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" redo
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" restore -Id <id> -Force -SyncDeps
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" remove -Id <id>
-powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo-savepoint.ps1" prune -KeepAuto 20
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" list
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" snapshot -Label "原因"
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" undo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" undo -SyncDeps
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" redo
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" restore -Id <id> -Force
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" restore -Id <id> -Force -SyncDeps
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" remove -Id <id>
+powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-undo.ps1" prune -KeepAuto 20
 
 # 安装插件（自动前后存档，失败自动回退）
 powershell -NoProfile -ExecutionPolicy Bypass -File "tools\dsh-plugin.ps1" add <包名>

--- a/tools/launch-undo.desktop
+++ b/tools/launch-undo.desktop
@@ -2,7 +2,10 @@
 Type=Application
 Name=dsh-undo-savepoint 局外 WebUI
 Comment=DSH 挂掉时的一键回退面板（配置/插件/健康）
-Exec=sh -c 'exec node "$(dirname "$0")/undo-server.mjs" "$@"' -- %k
+# L2 修复：模板被拷到桌面后无法用 %k 定位插件目录（$0='--'，dirname 失效），
+# 改为按标准安装布局自查找 tools/launch-undo.sh（与 make-desktop-shortcut.ps1 同源）。
+# 插件自动生成的那个 .desktop（ensureDesktopShortcut）用的是绝对路径，不受此影响。
+Exec=sh -c 'for d in "$HOME/.dsh/profiles/web/node_modules/dsh-undo-savepoint/tools" "$HOME/.dsh/profiles/node_modules/dsh-undo-savepoint/tools" "$HOME/node_modules/dsh-undo-savepoint/tools"; do if [ -x "$d/launch-undo.sh" ]; then exec "$d/launch-undo.sh" "$@"; fi; done; echo "dsh-undo-savepoint not found - install the plugin first" >&2; read x' -- %k
 Icon=system-file-manager
 Terminal=true
 Categories=Utility;


### PR DESCRIPTION
# docs: README 修正 CLI 文件名 + desktop 模板自查找修复

> Closes #31

## 改动

- `README.md` / `README.en.md`:离线 CLI 命令示例 `tools\dsh-undo-savepoint.ps1` → `tools\dsh-undo.ps1`(实际文件名)
- `tools/launch-undo.desktop`:`Exec` 从 `dirname "$0"`(拷到桌面后 $0='--' 失效)改为按标准安装布局自查找 `tools/launch-undo.sh`

## 验证

- README 中引用与 `tools/` 目录实际文件名一致
- desktop 模板在三个标准安装位置可正确找到启动脚本
