### PR TITLE
fix(client): use short cordis service names in client inject

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -934,7 +934,7 @@ window.__ModuleLoader__.load({
 		}
 		//#endregion
 		//#region client entry
-		const inject = ["@deepseek-ai/dsh-client-locale", "@deepseek-ai/dsh-client-ui-conversation", "@deepseek-ai/dsh-client-ui-settings"];
+		const inject = ["locale", "slots"];
 		function apply(ctx) {
 			// rc8 兼容盖子（2026-08-20）：客户端服务调用逐项 try/catch 降级，
 			// 单项失败只 console.warn 跳过，不拖垮整个 client（WebUI 半区保命）。

--- a/tools/smoke-test.mjs
+++ b/tools/smoke-test.mjs
@@ -1227,13 +1227,13 @@ console.log('== B4b. patch manifest: multi-version substrings + client declarati
   // 全不命中 → unmatched（驱动启动告警）
   const rJunk = matchPatchesInText('const x = 1;', manifest.patches);
   check(rJunk.unmatched.length === manifest.patches.length, 'B4b: unrelated text reports all unmatched');
-  // 声明回归守卫：inject 全包名 + engines 覆盖 rc.1 + client.js 与 package.json 一致
+  // 声明回归守卫：package.json 用全包名（模块图层）+ engines 覆盖 rc.1 + client.js 用短服务名（cordis 服务层，与 apply 实际 ctx.locale/ctx.slots 对齐；与 dsh-better-sidebar 同构，两层有意不一致，见 09-08-fix-web-boot-plugin）
   const pkg = JSON.parse(await readFile(fileURLToPath(new URL('../package.json', import.meta.url)), 'utf8'));
   const fullNames = ['@deepseek-ai/dsh-client-locale', '@deepseek-ai/dsh-client-ui-conversation', '@deepseek-ai/dsh-client-ui-settings'];
   check(JSON.stringify(pkg.dsh.client.inject) === JSON.stringify(fullNames), 'B4b: dsh.client.inject uses full package names');
   check(pkg.engines.dsh.includes('0.1.2-rc.1'), 'B4b: engines.dsh covers 0.1.2-rc.1');
   const clientText = await readFile(fileURLToPath(new URL('../lib/client.js', import.meta.url)), 'utf8');
-  check(clientText.includes('const inject = ["@deepseek-ai/dsh-client-locale", "@deepseek-ai/dsh-client-ui-conversation", "@deepseek-ai/dsh-client-ui-settings"];'), 'B4b: client.js inject mirrors package.json');
+  check(clientText.includes('const inject = ["locale", "slots"];'), 'B4b: client.js inject uses short service names');
 }
 
 console.log('== 38. B6: undo_scan — session health scan, fixable repair, corrupt isolation (v0.3.8) ==');


### PR DESCRIPTION
## Symptom

With v0.4.5 installed under the `web` profile, web boot fails with:

```
Failed to load plugins / web boot: 1 entry did not activate
dsh-undo-savepoint: pending (waiting for services: @deepseek-ai/dsh-client-locale, @deepseek-ai/dsh-client-ui-conversation, @deepseek-ai/dsh-client-ui-settings)
```

(The pending-services list is produced by the frontend `assertEntriesActive` check: `Object.keys(fiber.inject).filter(h => ctx.get(h) === undefined)`.)

## Root cause

`lib/client.js` declared its cordis injection with **full package names**:

```js
const inject = ["@deepseek-ai/dsh-client-locale", "@deepseek-ai/dsh-client-ui-conversation", "@deepseek-ai/dsh-client-ui-settings"];
```

but the client container only provides **short service names**: `locale` comes from `ctx.provide("locale", ...)` in `@deepseek-ai/dsh-client-locale`, and `slots` is a runtime builtin. So none of the three declared dependencies ever resolve and the entry stays pending.

Auditing `apply(ctx)` confirms it only touches `ctx.effect` (x2), `ctx.locale` (x2) and `ctx.slots` (x8) — there is no direct use of conversation/settings services. The fix aligns `inject` with what `apply` actually consumes:

```js
const inject = ["locale", "slots"];
```

This matches the existing convention in `dsh-better-sidebar` (`const inject = ["slots","sessions","connection","workspaces","locale","modules"]`) and `@anionex/dsh-vision-toolkit` (`['slots','locale','remote','conversation','sessions']`), plus the `dsh-cordis-client-runner` facade example (`{ inject: ['slots'], ... }`).

## Intentional two-layer split (please do not "fix" this back)

- `package.json:dsh.client.inject` **keeps the full package names** — that is the module/manifest layer.
- `lib/client.js` `const inject` uses short names — that is the cordis service layer.

The two layers legitimately disagree (same as `dsh-better-sidebar`). `tools/smoke-test.mjs` B4b now asserts exactly this split instead of asserting the two mirror each other.

## Changes (2 files, +3/-3)

- `lib/client.js:937` — short service names in `const inject`
- `tools/smoke-test.mjs:1230-1236` (B4b) — assert `package.json` keeps full names AND `client.js` uses short names

## Test evidence (re-run on this branch)

`npm test` components, all green (Node v26.7.0, `DSH_ROOT` pointed at local DSH install for peer-dep resolution):

- `check-size`: OK (764590 bytes < 5MB)
- `check-version`: OK 0.4.5
- `check-routes`: parity OK (19 routes both ends)
- `smoke-test.mjs`: **245 passed, 0 failed**, B4b 11/11 including the new `B4b: client.js inject uses short service names`
- `undo-server-smoke.mjs`: 9 passed, 0 failed
- `home-resolution-test.mjs`: 2 branches passed, 0 failed
- `e2e-watch.mjs`: 14 passed, 0 failed

Locally verified end-to-end before this PR: `dsh --profile web --dump-config` exit 0 with a full 670-line tree, served `client.js` contains the short-name line with zero full-package references, and host logs show no `did not activate` / `pending.*waiting` entries.

## Rollback

Revert this single commit; the old B4b mirror assertion comes back with it, so `npm test` stays self-consistent either way.